### PR TITLE
Update generate.yml - Change cron schedule to run every hour

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -2,7 +2,7 @@ name: Generate and Deploy
 
 on:
   schedule:
-    - cron: '25 */4 * * *'  # 25th minute of every 4th hour
+    - cron: '25 * * * *'  # 25th minute of every 4th hour
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updated the GitHub Actions workflow to trigger the job every 1 hour instead of every 4 hours. This ensures more frequent updates.